### PR TITLE
Spatial data provider implemented with NetTopologySuite

### DIFF
--- a/XPOSqlServerSpatial/XPOSqlServerSpatial.sln
+++ b/XPOSqlServerSpatial/XPOSqlServerSpatial.sln
@@ -1,9 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31424.327
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XPOSqlServerSpatial", "XPOSqlServerSpatial\XPOSqlServerSpatial.csproj", "{4947726F-966E-4E40-9C92-99AC2E704A7B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XPOSqlServerSpatialNTS", "XPOSqlServerSpatialNTS\XPOSqlServerSpatialNTS.csproj", "{2B49B2A6-3EDB-4F56-841D-7BAC113B2F8E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -12,11 +14,17 @@ Global
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{4947726F-966E-4E40-9C92-99AC2E704A7B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{4947726F-966E-4E40-9C92-99AC2E704A7B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4947726F-966E-4E40-9C92-99AC2E704A7B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4947726F-966E-4E40-9C92-99AC2E704A7B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2B49B2A6-3EDB-4F56-841D-7BAC113B2F8E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2B49B2A6-3EDB-4F56-841D-7BAC113B2F8E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2B49B2A6-3EDB-4F56-841D-7BAC113B2F8E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2B49B2A6-3EDB-4F56-841D-7BAC113B2F8E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {9E2D1A7E-5C73-4ADE-B34A-867BDD83FC28}
 	EndGlobalSection
 EndGlobal

--- a/XPOSqlServerSpatial/XPOSqlServerSpatialNTS/Program.cs
+++ b/XPOSqlServerSpatial/XPOSqlServerSpatialNTS/Program.cs
@@ -1,0 +1,166 @@
+﻿using DevExpress.Xpo;
+using DevExpress.Xpo.DB;
+using DevExpress.Xpo.Metadata;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+using System;
+using System.Data;
+using System.Data.SqlClient;
+using System.IO;
+
+namespace XPOSqlServerSpatialNTS
+{
+
+    public class GISProvider : MSSqlConnectionProvider
+    {
+        public GISProvider(IDbConnection connection, AutoCreateOption autoCreateOption)
+          : base(connection, autoCreateOption)
+        {
+        }
+
+        protected override void GetValues(IDataReader reader, Type[] fieldTypes, object[] values)
+        {
+            // A direct read of the geometry field with the GetValue method will produce Microsoft.SqlServer.Types exception.
+            // So it's necessary to determine that field is geometry and read it as bytes.
+            for (int i = 0; i < reader.FieldCount; i++)
+            {
+                if (!reader.GetDataTypeName(i).EndsWith("sys.geometry") ||
+                    reader.IsDBNull(i))
+                {
+                    values[i] = reader.GetValue(i);
+                }
+                else
+                {
+                    // Cast to SqlDataReader to read the bytes  
+                    // values[i] = (reader as SqlDataReader).GetSqlBytes(i).Value;
+
+                    // Or use memory stream to read the field
+                    values[i] = GetBytes(reader, i);
+                }
+            }
+        }
+
+        private static byte[] GetBytes(IDataReader reader, int i)
+        {
+            using MemoryStream memoryStream = new();
+            byte[] buffer = new byte[8192];
+            long offset = 0;
+            long bytesRead = 0;
+            do
+            {
+                bytesRead = reader.GetBytes(i, offset, buffer, 0, buffer.Length);
+                memoryStream.Write(buffer, 0, (int)bytesRead);
+                offset += bytesRead;
+            } while (bytesRead >= buffer.Length);
+            return memoryStream.ToArray();
+        }
+    }
+
+    public class PolygonData : XPObject
+    {
+        public PolygonData(Session session)
+          : base(session) { }
+
+        private string name;
+        public string Name
+        {
+            get { return name; }
+            set { SetPropertyValue(nameof(Name), ref name, value); }
+        }
+
+        Geometry fGeom;
+        [ValueConverter(typeof(GeometryConverter))]
+        [DbType("geometry")]
+        public Geometry Geom
+        {
+            get { return fGeom; }
+            set { SetPropertyValue(nameof(Geom), ref fGeom, value); }
+        }
+    }
+
+    public class GeometryConverter : ValueConverter
+    {
+        public override object ConvertFromStorageType(object value)
+        {
+            if (value != null)
+            {
+                var geometryReader = new SqlServerBytesReader { IsGeography = false, RepairRings = true };
+                return geometryReader.Read((byte[])value);
+            }
+            else
+                return null;
+        }
+
+        public override object ConvertToStorageType(object value)
+        {
+            if (value == null) return null;
+
+            if (value is Geometry geometry)
+            {
+                return new SqlServerBytesWriter().Write(geometry);
+            }
+            else return value;
+        }
+
+        public override Type StorageType
+        {
+            get { return typeof(byte[]); }
+        }
+    }
+
+    class Program
+    {
+        private static Polygon CreatePolygon()
+        {
+            Polygon polygon = new(
+                new LinearRing(
+                    new Coordinate[] {
+                    new Coordinate(734352.631, 6909426.235),
+                    new Coordinate(542625.097, 5882056.051),
+                    new Coordinate(1678520.300, 5730121.024),
+                    new Coordinate(1888335.337, 6663436.191),
+                    new Coordinate(1468705.262, 6970923.746),
+                    new Coordinate(734352.631, 6909426.235)
+            }));
+            polygon.SRID = 3857;
+
+            return polygon;
+        }
+
+        static void Main(string[] args)
+        {
+            XpoDefault.DataLayer =
+              new SimpleDataLayer(new GISProvider(
+                new SqlConnection("data source=localhost;integrated security=SSPI;initial catalog=XPOSql2008Spatial"),
+                AutoCreateOption.DatabaseAndSchema));
+
+            using (UnitOfWork uow = new())
+            {
+                uow.ClearDatabase();
+                uow.UpdateSchema(typeof(PolygonData));
+            }
+
+            using (UnitOfWork uow = new())
+            {
+                new PolygonData(uow)
+                {
+                    Name = "Test 1",
+                    Geom = CreatePolygon()
+                }.Save();
+                uow.CommitChanges();
+            }
+
+            using (UnitOfWork uow = new())
+            {
+                var polygons = new XPCollection<PolygonData>();
+                foreach (var polygon in polygons)
+                {
+                    Console.WriteLine("Name: " + polygon.Name);
+                    Console.WriteLine("SRID: " + polygon.Geom.SRID);
+                    Console.WriteLine("Polygon: " + polygon.Geom.ToString());
+                }
+            }
+
+        }
+    }
+}

--- a/XPOSqlServerSpatial/XPOSqlServerSpatialNTS/XPOSqlServerSpatialNTS.csproj
+++ b/XPOSqlServerSpatial/XPOSqlServerSpatialNTS/XPOSqlServerSpatialNTS.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="DevExpress.Xpo" Version="21.1.4" />
+    <PackageReference Include="NetTopologySuite.IO.SqlServerBytes" Version="2.0.0" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This implementation uses the NetTopologySuite.IO.SqlServerBytes package included in NetTopologySuite to read/write geometry fields as bytes. 
It also can be modified to access fields with Geography database type. To do this just set IsGeography property of the SqlServerBytesReader instance to false.